### PR TITLE
fix releaseDate error for fbaInbound

### DIFF
--- a/fbaInbound/types.gen.go
+++ b/fbaInbound/types.gen.go
@@ -550,7 +550,7 @@ type InboundShipmentItem struct {
 
 	// The item quantity.
 	QuantityShipped Quantity        `json:"QuantityShipped"`
-	ReleaseDate     *DateStringType `json:"ReleaseDate,omitempty"`
+	ReleaseDate     *string `json:"ReleaseDate,omitempty"`
 
 	// The seller SKU of the item.
 	SellerSKU string `json:"SellerSKU"`


### PR DESCRIPTION
Update `InboundShipmentItem` `ReleaseDate` type from DateStringType to string to avoid parsing error.