### PR TITLE
Replace gopkg to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ~~~~
-go get -u gopkg.me/selling-partner-api-sdk
+go get -u github.com/amzapi/selling-partner-api-sdk
 ~~~~
 
 ## Progress
@@ -43,8 +43,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	
-	sp "gopkg.me/selling-partner-api-sdk/pkg/selling-partner"
-	"gopkg.me/selling-partner-api-sdk/sellers"
+	sp "github.com/amzapi/selling-partner-api-sdk/pkg/selling-partner"
+	"github.com/amzapi/selling-partner-api-sdk/sellers"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"

--- a/authorization/api.gen.go
+++ b/authorization/api.gen.go
@@ -13,7 +13,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/catalog/api.gen.go
+++ b/catalog/api.gen.go
@@ -13,7 +13,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/fbaInbound/api.gen.go
+++ b/fbaInbound/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/fbaInbound/types.gen.go
+++ b/fbaInbound/types.gen.go
@@ -6,7 +6,7 @@ package fbaInbound
 import (
 	"time"
 
-	openapi_types "gopkg.me/selling-partner-api-sdk/pkg/types"
+	openapi_types "github.com/amzapi/selling-partner-api-sdk/pkg/types"
 )
 
 // ASINInboundGuidance defines model for ASINInboundGuidance.

--- a/fbaInventory/api.gen.go
+++ b/fbaInventory/api.gen.go
@@ -13,7 +13,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/fbaOutbound/api.gen.go
+++ b/fbaOutbound/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/feeds/api.gen.go
+++ b/feeds/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/fees/api.gen.go
+++ b/fees/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/finances/api.gen.go
+++ b/finances/api.gen.go
@@ -13,7 +13,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.me/selling-partner-api-sdk
+module github.com/amzapi/selling-partner-api-sdk
 
 go 1.16
 

--- a/merchantFulfillment/api.gen.go
+++ b/merchantFulfillment/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/messaging/api.gen.go
+++ b/messaging/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/notifications/api.gen.go
+++ b/notifications/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/ordersV0/api.gen.go
+++ b/ordersV0/api.gen.go
@@ -13,7 +13,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/types"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/types"
 )
 
 // This function binds a parameter as described in the Path Parameters

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/types"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/types"
 )
 
 func TestSplitParameter(t *testing.T) {

--- a/pkg/runtime/bindstring.go
+++ b/pkg/runtime/bindstring.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"time"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/types"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/types"
 )
 
 // This function takes a string, and attempts to assign it to the destination

--- a/pkg/runtime/bindstring_test.go
+++ b/pkg/runtime/bindstring_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/types"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/types"
 )
 
 func TestBindStringToObject(t *testing.T) {

--- a/pkg/runtime/deepobject.go
+++ b/pkg/runtime/deepobject.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/types"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/types"
 )
 
 func marshalDeepObject(in interface{}, path []string) ([]string, error) {

--- a/productPricing/api.gen.go
+++ b/productPricing/api.gen.go
@@ -13,7 +13,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/reports/api.gen.go
+++ b/reports/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/sales/api.gen.go
+++ b/sales/api.gen.go
@@ -13,7 +13,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/service/api.gen.go
+++ b/service/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/shipping/api.gen.go
+++ b/shipping/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/smallAndLight/api.gen.go
+++ b/smallAndLight/api.gen.go
@@ -15,7 +15,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/solicitations/api.gen.go
+++ b/solicitations/api.gen.go
@@ -13,7 +13,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function

--- a/uploads/api.gen.go
+++ b/uploads/api.gen.go
@@ -13,7 +13,7 @@ import (
 	runt "runtime"
 	"strings"
 
-	"gopkg.me/selling-partner-api-sdk/pkg/runtime"
+	"github.com/amzapi/selling-partner-api-sdk/pkg/runtime"
 )
 
 // RequestBeforeFn  is the function signature for the RequestBefore callback function


### PR DESCRIPTION
The gopkg.me seems out of order. So, I'm replacing the gopkg to github as default enabling the SDK usage in a simple way. 