### PR TITLE
update api version and response for getReportDocument

### DIFF
--- a/reports/api.gen.go
+++ b/reports/api.gen.go
@@ -464,6 +464,7 @@ func NewGetReportDocumentRequest(endpoint string, reportDocumentId string, args 
 	}
 
 	// Effective June 27, 2023, the Selling Partner API for Reports v2020-09-04 will no longer be available and all calls to it will fail. Integrations that rely on the Reports API must migrate to Reports v2021-06-30 to avoid service disruption
+	// https://developer-docs.amazon.com/sp-api/docs/reports-api-v2021-06-30-reference#reportdocument
 	basePath := fmt.Sprintf("/reports/2020-09-04/documents/%s", pathParam0)
 	if len(args) > 0 {
 		if args[0] == "2020-09-04" || args[0] == "2021-06-30" {
@@ -489,6 +490,7 @@ func NewGetReportDocumentRequest(endpoint string, reportDocumentId string, args 
 
 // NewGetReportsRequest generates requests for GetReports
 // Effective June 27, 2023, the Selling Partner API for Reports v2020-09-04 will no longer be available and all calls to it will fail. Integrations that rely on the Reports API must migrate to Reports v2021-06-30 to avoid service disruption
+// https://developer-docs.amazon.com/sp-api/docs/reports-api-v2021-06-30-reference#reportdocument
 func NewGetReportsRequest(endpoint string, params *GetReportsParams) (*http.Request, error) {
 	var err error
 

--- a/reports/api.gen.go
+++ b/reports/api.gen.go
@@ -463,13 +463,9 @@ func NewGetReportDocumentRequest(endpoint string, reportDocumentId string, args 
 		return nil, err
 	}
 
-	// Effective June 27, 2023, the Selling Partner API for Reports v2020-09-04 will no longer be available and all calls to it will fail. Integrations that rely on the Reports API must migrate to Reports v2021-06-30 to avoid service disruption
-	// https://developer-docs.amazon.com/sp-api/docs/reports-api-v2021-06-30-reference#reportdocument
 	basePath := fmt.Sprintf("/reports/2020-09-04/documents/%s", pathParam0)
-	if len(args) > 0 {
-		if args[0] == "2020-09-04" || args[0] == "2021-06-30" {
-			basePath = fmt.Sprintf("/reports/%s/documents/%s", args[0], pathParam0)
-		}
+	if len(args) > 0 && args[0] == "2021-06-30" {
+		basePath = fmt.Sprintf("/reports/%s/documents/%s", args[0], pathParam0)
 	}
 	if basePath[0] == '/' {
 		basePath = basePath[1:]
@@ -489,8 +485,6 @@ func NewGetReportDocumentRequest(endpoint string, reportDocumentId string, args 
 }
 
 // NewGetReportsRequest generates requests for GetReports
-// Effective June 27, 2023, the Selling Partner API for Reports v2020-09-04 will no longer be available and all calls to it will fail. Integrations that rely on the Reports API must migrate to Reports v2021-06-30 to avoid service disruption
-// https://developer-docs.amazon.com/sp-api/docs/reports-api-v2021-06-30-reference#reportdocument
 func NewGetReportsRequest(endpoint string, params *GetReportsParams) (*http.Request, error) {
 	var err error
 
@@ -499,10 +493,8 @@ func NewGetReportsRequest(endpoint string, params *GetReportsParams) (*http.Requ
 		return nil, err
 	}
 	basePath := fmt.Sprintf("/reports/2020-09-04/reports")
-	if params.APIVersion != nil{
-		if *params.APIVersion == "2020-09-04" || *params.APIVersion == "2021-06-30" {
-			basePath = fmt.Sprintf("/reports/%s/reports", *params.APIVersion)
-		}
+	if params.APIVersion != nil && *params.APIVersion == "2021-06-30"{
+		basePath = fmt.Sprintf("/reports/%s/reports", *params.APIVersion)
 	}
 	if basePath[0] == '/' {
 		basePath = basePath[1:]

--- a/reports/api.gen.go
+++ b/reports/api.gen.go
@@ -125,7 +125,7 @@ func WithResponseAfter(fn ResponseAfterFn) ClientOption {
 // The interface specification for the client above.
 type ClientInterface interface {
 	// GetReportDocument request
-	GetReportDocument(ctx context.Context, reportDocumentId string) (*http.Response, error)
+	GetReportDocument(ctx context.Context, reportDocumentId string, args ...string) (*http.Response, error)
 
 	// GetReports request
 	GetReports(ctx context.Context, params *GetReportsParams) (*http.Response, error)
@@ -156,8 +156,8 @@ type ClientInterface interface {
 	GetReportSchedule(ctx context.Context, reportScheduleId string) (*http.Response, error)
 }
 
-func (c *Client) GetReportDocument(ctx context.Context, reportDocumentId string) (*http.Response, error) {
-	req, err := NewGetReportDocumentRequest(c.Endpoint, reportDocumentId)
+func (c *Client) GetReportDocument(ctx context.Context, reportDocumentId string, args ...string) (*http.Response, error) {
+	req, err := NewGetReportDocumentRequest(c.Endpoint, reportDocumentId, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +448,7 @@ func (c *Client) GetReportSchedule(ctx context.Context, reportScheduleId string)
 }
 
 // NewGetReportDocumentRequest generates requests for GetReportDocument
-func NewGetReportDocumentRequest(endpoint string, reportDocumentId string) (*http.Request, error) {
+func NewGetReportDocumentRequest(endpoint string, reportDocumentId string, args ...string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -463,7 +463,13 @@ func NewGetReportDocumentRequest(endpoint string, reportDocumentId string) (*htt
 		return nil, err
 	}
 
+	// Effective June 27, 2023, the Selling Partner API for Reports v2020-09-04 will no longer be available and all calls to it will fail. Integrations that rely on the Reports API must migrate to Reports v2021-06-30 to avoid service disruption
 	basePath := fmt.Sprintf("/reports/2020-09-04/documents/%s", pathParam0)
+	if len(args) > 0 {
+		if args[0] == "2020-09-04" || args[0] == "2021-06-30" {
+			basePath = fmt.Sprintf("/reports/%s/documents/%s", args[0], pathParam0)
+		}
+	}
 	if basePath[0] == '/' {
 		basePath = basePath[1:]
 	}
@@ -482,6 +488,7 @@ func NewGetReportDocumentRequest(endpoint string, reportDocumentId string) (*htt
 }
 
 // NewGetReportsRequest generates requests for GetReports
+// Effective June 27, 2023, the Selling Partner API for Reports v2020-09-04 will no longer be available and all calls to it will fail. Integrations that rely on the Reports API must migrate to Reports v2021-06-30 to avoid service disruption
 func NewGetReportsRequest(endpoint string, params *GetReportsParams) (*http.Request, error) {
 	var err error
 
@@ -489,8 +496,12 @@ func NewGetReportsRequest(endpoint string, params *GetReportsParams) (*http.Requ
 	if err != nil {
 		return nil, err
 	}
-
 	basePath := fmt.Sprintf("/reports/2020-09-04/reports")
+	if params.APIVersion != nil{
+		if *params.APIVersion == "2020-09-04" || *params.APIVersion == "2021-06-30" {
+			basePath = fmt.Sprintf("/reports/%s/reports", *params.APIVersion)
+		}
+	}
 	if basePath[0] == '/' {
 		basePath = basePath[1:]
 	}
@@ -911,8 +922,8 @@ func WithBaseURL(baseURL string) ClientOption {
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
 	// GetReportDocument request
-	GetReportDocumentWithResponse(ctx context.Context, reportDocumentId string) (*GetReportDocumentResp, error)
-
+	GetReportDocumentWithResponse(ctx context.Context, reportDocumentId string, params ...string) (*GetReportDocumentResp, error)
+	
 	// GetReports request
 	GetReportsWithResponse(ctx context.Context, params *GetReportsParams) (*GetReportsResp, error)
 
@@ -1141,8 +1152,8 @@ func (r GetReportScheduleResp) StatusCode() int {
 }
 
 // GetReportDocumentWithResponse request returning *GetReportDocumentResponse
-func (c *ClientWithResponses) GetReportDocumentWithResponse(ctx context.Context, reportDocumentId string) (*GetReportDocumentResp, error) {
-	rsp, err := c.GetReportDocument(ctx, reportDocumentId)
+func (c *ClientWithResponses) GetReportDocumentWithResponse(ctx context.Context, reportDocumentId string, args ...string) (*GetReportDocumentResp, error) {
+	rsp, err := c.GetReportDocument(ctx, reportDocumentId, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/reports/types.gen.go
+++ b/reports/types.gen.go
@@ -115,6 +115,14 @@ type GetReportDocumentResponse struct {
 	// A list of error responses returned when a request is unsuccessful.
 	Errors  *ErrorList      `json:"errors,omitempty"`
 	Payload *ReportDocument `json:"payload,omitempty"`
+	// The identifier for the report document. This identifier is unique only in combination with a seller ID.
+	ReportDocumentId *string `json:"reportDocumentId"`
+
+	// A presigned URL for the report document. This URL expires after 5 minutes.
+	Url *string `json:"url,omitempty"`
+
+	// If present, the report document contents have been compressed with the provided algorithm.
+	CompressionAlgorithm *string `json:"compressionAlgorithm,omitempty"`
 }
 
 // GetReportResponse defines model for GetReportResponse.
@@ -152,6 +160,9 @@ type GetReportsResponse struct {
 	// Returned when the number of results exceeds pageSize. To get the next page of results, call getReports with this token as the only parameter.
 	NextToken *string     `json:"nextToken,omitempty"`
 	Payload   *ReportList `json:"payload,omitempty"`
+
+	// from new API version
+	Reports   *ReportList `json:"reports,omitempty"`
 }
 
 // Report defines model for Report.
@@ -276,6 +287,9 @@ type GetReportsParams struct {
 
 	// A string token returned in the response to your previous request. nextToken is returned when the number of results exceeds the specified pageSize value. To get the next page of results, call the getReports operation and include this token as the only parameter. Specifying nextToken with any other parameters will cause the request to fail.
 	NextToken *string `json:"nextToken,omitempty"`
+
+	// Can be used to set the API version used
+	APIVersion *string `json:"apiVersion,omitempty"`
 }
 
 // CreateReportJSONBody defines parameters for CreateReport.


### PR DESCRIPTION
Update GetReportDocument Response and API version according to the new [API documentation](https://developer-docs.amazon.com/sp-api/docs/reports-api-v2021-06-30-reference#reportdocument).

Notes from documentation:

Effective June 27, 2023, the Selling Partner API for Reports v2020-09-04 will no longer be available and all calls to it will fail. Integrations that rely on the Reports API must migrate to Reports v2021-06-30 to avoid service disruption

Here is the notification that in 22 days(June 23, 2023) the old API version will be depracated.
https://developer-docs.amazon.com/sp-api/docs/reports-api-v2020-09-01-reference