### PR TITLE
#11: orders NextToken fix

### DIFF
--- a/ordersV0/api.gen.go
+++ b/ordersV0/api.gen.go
@@ -526,17 +526,7 @@ func NewGetOrdersRequest(endpoint string, params *GetOrdersParams) (*http.Reques
 
 	if params.NextToken != nil {
 
-		if queryFrag, err := runtime.StyleParam("form", true, "NextToken", *params.NextToken); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
+		queryValues.Add("NextToken", *params.NextToken)
 
 	}
 


### PR DESCRIPTION
I know, the code is autogenerated, but it's the only way how to use NextToken with Orders API, otherwise it's broken.