### PR TITLE
Added SellerId to Offer Details

### DIFF
--- a/productPricing/types.gen.go
+++ b/productPricing/types.gen.go
@@ -252,6 +252,8 @@ type OfferDetail struct {
 	// When true, this is the seller's offer.
 	MyOffer *bool   `json:"MyOffer,omitempty"`
 	Points  *Points `json:"Points,omitempty"`
+
+	// The seller identifier for the offer.
 	SellerId *string `json:"SellerId,omitempty"`
 
 	// Information about the seller's feedback, including the percentage of positive feedback, and the total number of ratings received.

--- a/productPricing/types.gen.go
+++ b/productPricing/types.gen.go
@@ -252,6 +252,7 @@ type OfferDetail struct {
 	// When true, this is the seller's offer.
 	MyOffer *bool   `json:"MyOffer,omitempty"`
 	Points  *Points `json:"Points,omitempty"`
+	SellerId *string `json:"SellerId,omitempty"`
 
 	// Information about the seller's feedback, including the percentage of positive feedback, and the total number of ratings received.
 	SellerFeedbackRating *SellerFeedbackType `json:"SellerFeedbackRating,omitempty"`


### PR DESCRIPTION
Added the SellerId to the Offer Details in the Product Pricing API response. The API documentation is as follows.
https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-reference#offerdetail